### PR TITLE
Includes fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ SUBDIRS = xingmp3 libmp3
 LOCAL_CLEAN = build/*.o build/*.a
 # SUBDIRS = mpglib libmp3
 
+# The code is old and cant stand modern scrutiny
+CFLAGS +=  -std=c17
+
 defaultall: create_kos_link $(OBJS) subdirs linklib
 
 include $(KOS_BASE)/addons/Makefile.prefab

--- a/libmp3/sndmp3.c
+++ b/libmp3/sndmp3.c
@@ -28,6 +28,7 @@
 #include <dc/sound/stream.h>
 #include <kos/sem.h>
 #include <kos/thread.h>
+#include <kos/fs.h>
 
 /************************************************************************/
 #include <mhead.h>		/* From xingmp3 */


### PR DESCRIPTION
We're using `fs_read` but weren't including it. This was
due to it being patched in through stdio.h. Adding this
include will allow for the removal of that old patching.

This is the same patching that was referenced in [#kallistios/1000](https://github.com/KallistiOS/KallistiOS/pull/1000)
