### PR TITLE
Makefile: Propagate c17 standard to subdirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ SUBDIRS = xingmp3 libmp3
 LOCAL_CLEAN = build/*.o build/*.a
 # SUBDIRS = mpglib libmp3
 
-# The code is old and cant stand modern scrutiny
-CFLAGS +=  -std=c17
-
 defaultall: create_kos_link $(OBJS) subdirs linklib
 
 include $(KOS_BASE)/addons/Makefile.prefab

--- a/libmp3/Makefile
+++ b/libmp3/Makefile
@@ -6,7 +6,7 @@
 OBJS = main.o sndmp3.o
 
 BUILD_TARGET = addons/libmp3
-KOS_CFLAGS += -I../xingmp3 -I../include
+CFLAGS += -I../xingmp3 -I../include -std=c17
 # KOS_LOCAL_CFLAGS = -I../mpglib
 
 all: $(OBJS)

--- a/xingmp3/Makefile
+++ b/xingmp3/Makefile
@@ -3,7 +3,7 @@ OBJS += cwinm.o dec8.o hwin.o icdct.o isbt.o
 OBJS += iup.o iwinm.o l3dq.o l3init.o
 OBJS += mdct.o mhead.o msis.o uph.o upsf.o
 INCS += -I. -DLITTLE_ENDIAN=1
-CFLAGS += -O2
+CFLAGS += -O2 -std=c17
 
 all: libxingmp3.a
 libxingmp3.a: $(OBJS)


### PR DESCRIPTION
Otherwise it would only apply at the top level where there are no cflags at all. If it was KOS_CFLAGS then it would apply to all, but would not show up as different from standard KOS_CFLAGS on output.